### PR TITLE
v2.0.0 Markdown Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [2.0.0] - 2025-08-11
+
+### Added
+- **Full Markdown content support** - Major new feature for highlighting text in Markdown documents
+  - New `markdownContent` prop as an alternative to HTML children
+  - Automatic rendering of Markdown to HTML using the `marked` library
+  - Tag positions stored as actual Markdown source file positions (including formatting characters)
+  - Support for highlighting text that spans across Markdown formatting (bold, italic, links, etc.)
+  - Complete support for all standard Markdown features:
+    - Headers (H1-H6)
+    - Bold and italic text
+    - Links with URLs
+    - Inline code and code blocks
+    - Lists (ordered and unordered)
+    - Tables
+    - Mixed and nested formatting
+
+### Changed
+- `HiLiteContent` now accepts either `children` (HTML) or `markdownContent` (Markdown string)
+- Enhanced position mapping system to handle both HTML and Markdown content
+- Updated TypeScript types to support the new Markdown mode
+
+### Technical Implementation
+- New `MarkdownMapper` utility class for handling Markdown parsing and position mapping
+- Bidirectional mapping between Markdown source positions and rendered HTML text positions
+- Intelligent handling of Markdown syntax characters during text selection
+- Preservation of exact file positions for database storage and retrieval
+
+### Developer Experience
+- Seamless integration - existing HTML mode continues to work without changes
+- Import Markdown files directly with Vite/Webpack using `import content from "./file.md?raw"`
+- Comprehensive position tracking for accurate tag restoration
+- Full backward compatibility - no breaking changes for existing users
+
+### Documentation
+- Added comprehensive Markdown usage guide to README
+- Updated API reference with new `markdownContent` prop
+- Added examples for both inline Markdown strings and file imports
+- Detailed explanation of how Markdown indexing works
+
+---
+
 ## [1.3.4] - 2025-06-19
 
 ### Added

--- a/hilitetag/package-lock.json
+++ b/hilitetag/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "hilitetag",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hilitetag",
-      "version": "0.0.0",
+      "version": "1.3.4",
       "dependencies": {
+        "@types/marked": "^5.0.2",
+        "marked": "^16.1.2",
         "nanoid": "^5.1.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -1404,6 +1406,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/marked": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.2.tgz",
+      "integrity": "sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
@@ -2612,6 +2620,18 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/merge2": {

--- a/hilitetag/package.json
+++ b/hilitetag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hilitetag",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,6 +22,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/marked": "^5.0.2",
+    "marked": "^16.1.2",
     "nanoid": "^5.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/hilitetag/src/core/MarkdownMapper.ts
+++ b/hilitetag/src/core/MarkdownMapper.ts
@@ -1,0 +1,225 @@
+import { marked } from 'marked';
+
+/**
+ * Maps positions between Markdown source text and rendered HTML text content
+ */
+export class MarkdownMapper {
+  private markdownSource: string;
+  private htmlContent: string;
+  private textContent: string;
+  
+  constructor(markdownSource: string) {
+    this.markdownSource = markdownSource;
+    this.htmlContent = marked.parse(markdownSource) as string;
+    this.textContent = '';
+    this.buildTextContent();
+  }
+  
+  /**
+   * Get the HTML content
+   */
+  getHtml(): string {
+    return this.htmlContent;
+  }
+  
+  /**
+   * Get the plain text content (without any Markdown formatting)
+   */
+  getTextContent(): string {
+    return this.textContent;
+  }
+  
+  /**
+   * Build text content from HTML
+   */
+  private buildTextContent(): void {
+    // Create a temporary DOM to extract text content
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = this.htmlContent;
+    
+    // Extract all text content from the HTML
+    const walker = document.createTreeWalker(
+      tempDiv,
+      NodeFilter.SHOW_TEXT,
+      null
+    );
+    
+    const textParts: string[] = [];
+    
+    // Collect all text nodes
+    while (walker.nextNode()) {
+      const node = walker.currentNode as Text;
+      const text = node.textContent || '';
+      textParts.push(text);
+    }
+    
+    this.textContent = textParts.join('');
+    console.log(`HTML text content (first 200 chars): "${this.textContent.substring(0, 200)}"`);
+    console.log(`HTML text content (last 200 chars): "${this.textContent.substring(Math.max(0, this.textContent.length - 200))}"`);
+  }
+  
+  /**
+   * Convert HTML text range to Markdown source range
+   * Returns the ACTUAL character positions in the markdown file
+   */
+  mapHtmlRangeToMarkdown(htmlStartPos: number, htmlEndPos: number): { start: number; end: number } {
+    // Get the text we're looking for from the HTML text content
+    const searchText = this.textContent.substring(htmlStartPos, htmlEndPos);
+    
+    if (!searchText) {
+      return { start: 0, end: 0 };
+    }
+    
+    console.log(`Searching for text in markdown: "${searchText}"`);
+    
+    // First, try to find exact match in markdown
+    let index = this.markdownSource.indexOf(searchText);
+    
+    if (index !== -1) {
+      console.log(`Found exact match at positions [${index}, ${index + searchText.length}]`);
+      return { start: index, end: index + searchText.length };
+    }
+    
+    // If not found, the text might be split by formatting
+    // Try to find it by searching for parts
+    const words = searchText.split(/\s+/);
+    if (words.length > 0) {
+      // Search for the first word to get a starting point
+      const firstWord = words[0];
+      let searchFrom = 0;
+      
+      while (searchFrom < this.markdownSource.length) {
+        const wordIndex = this.markdownSource.indexOf(firstWord, searchFrom);
+        if (wordIndex === -1) break;
+        
+        // Check if we can match all words from this position
+        let pos = wordIndex;
+        let matched = true;
+        
+        for (let i = 0; i < words.length; i++) {
+          const word = words[i];
+          const foundAt = this.findWordIgnoringFormatting(word, pos);
+          
+          if (foundAt === -1) {
+            matched = false;
+            break;
+          }
+          
+          pos = foundAt + word.length;
+        }
+        
+        if (matched) {
+          // Found all words, now find the exact range
+          const start = wordIndex;
+          const end = pos;
+          
+          // Adjust to include any formatting
+          let actualStart = start;
+          let actualEnd = end;
+          
+          // Look back for opening formatting
+          while (actualStart > 0 && this.isPartOfSameFormattingBlock(actualStart - 1, searchText)) {
+            actualStart--;
+          }
+          
+          // Look forward for closing formatting
+          while (actualEnd < this.markdownSource.length && this.isPartOfSameFormattingBlock(actualEnd, searchText)) {
+            actualEnd++;
+          }
+          
+          console.log(`Found text with formatting at positions [${actualStart}, ${actualEnd}]`);
+          const extracted = this.markdownSource.substring(actualStart, actualEnd);
+          console.log(`Extracted: "${extracted}"`);
+          
+          return { start: actualStart, end: actualEnd };
+        }
+        
+        searchFrom = wordIndex + 1;
+      }
+    }
+    
+    console.error(`Failed to find text "${searchText}" in markdown`);
+    return { start: 0, end: 0 };
+  }
+  
+  /**
+   * Find a word starting from position, ignoring formatting
+   */
+  private findWordIgnoringFormatting(word: string, startPos: number): number {
+    let charIndex = 0;
+    
+    for (let i = startPos; i < this.markdownSource.length && charIndex < word.length; i++) {
+      const char = this.markdownSource[i];
+      
+      // Skip formatting characters
+      if (char === '*' || char === '_' || char === '`' || char === '[' || char === ']' || char === '(' || char === ')') {
+        continue;
+      }
+      
+      if (char === word[charIndex]) {
+        if (charIndex === 0) {
+          startPos = i; // Mark the actual start
+        }
+        charIndex++;
+      } else if (charIndex > 0) {
+        // We were matching but hit a non-match
+        return -1;
+      }
+    }
+    
+    return charIndex === word.length ? startPos : -1;
+  }
+  
+  /**
+   * Check if a position is part of the same formatting block
+   */
+  private isPartOfSameFormattingBlock(pos: number, text: string): boolean {
+    const char = this.markdownSource[pos];
+    // Check for formatting characters that might be part of this text's formatting
+    return char === '*' || char === '_' || char === '`';
+  }
+  
+
+  
+
+  
+  /**
+   * Convert Markdown source range to HTML text range
+   * Takes ACTUAL file positions and maps to HTML text positions
+   */
+  mapMarkdownRangeToHtml(markdownStartPos: number, markdownEndPos: number): { start: number; end: number } {
+    // Extract the text from the markdown at these positions
+    const markdownText = this.markdownSource.substring(markdownStartPos, markdownEndPos);
+    
+    // Remove markdown formatting to get pure text
+    const pureText = this.stripMarkdownFormatting(markdownText);
+    
+    // Find this text in the HTML text content
+    const htmlIndex = this.textContent.indexOf(pureText);
+    
+    if (htmlIndex !== -1) {
+      return { start: htmlIndex, end: htmlIndex + pureText.length };
+    }
+    
+    // If not found, try to find it more carefully
+    console.warn(`Could not find markdown text "${pureText}" in HTML`);
+    return { start: 0, end: pureText.length };
+  }
+  
+  /**
+   * Strip markdown formatting from text
+   */
+  private stripMarkdownFormatting(text: string): string {
+    // Remove common markdown formatting
+    return text
+      .replace(/\*\*([^*]+)\*\*/g, '$1')  // Bold **text**
+      .replace(/\*([^*]+)\*/g, '$1')      // Italic *text*
+      .replace(/__([^_]+)__/g, '$1')      // Bold __text__
+      .replace(/_([^_]+)_/g, '$1')        // Italic _text_
+      .replace(/`([^`]+)`/g, '$1')        // Inline code
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')  // Links [text](url)
+      .replace(/^#+\s+/gm, '')            // Headers
+      .replace(/^[-*+]\s+/gm, '')         // List markers
+      .replace(/^\d+\.\s+/gm, '');        // Numbered lists
+  }
+}

--- a/hilitetag/src/test-markdown.md
+++ b/hilitetag/src/test-markdown.md
@@ -1,0 +1,29 @@
+# Test Markdown for HiLiteTag
+
+This is a **test document** to verify the Markdown support.
+
+## Features to Test
+
+1. **Bold text** like this
+2. *Italic text* like this  
+3. `Inline code` snippets
+4. [Links](https://example.com) work too
+
+### Code Block Example
+
+```javascript
+function example() {
+  console.log("This is code");
+}
+```
+
+### Table Example
+
+| Column 1 | Column 2 |
+|----------|----------|
+| Data 1   | Data 2   |
+| Data 3   | Data 4   |
+
+This paragraph contains **multiple** *formatting* `styles` at once.
+
+You can select text that spans **across bold** and *italic* formatting.

--- a/hilitetag/src/vite-env.d.ts
+++ b/hilitetag/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module '*.md?raw' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Markdown Support [2.0.0] - 2025-08-11

### Added
- **Full Markdown content support** - Major new feature for highlighting text in Markdown documents
  - New `markdownContent` prop as an alternative to HTML children
  - Automatic rendering of Markdown to HTML using the `marked` library
  - Tag positions stored as actual Markdown source file positions (including formatting characters)
  - Support for highlighting text that spans across Markdown formatting (bold, italic, links, etc.)
  - Complete support for all standard Markdown features:
    - Headers (H1-H6)
    - Bold and italic text
    - Links with URLs
    - Inline code and code blocks
    - Lists (ordered and unordered)
    - Tables
    - Mixed and nested formatting

### Changed
- `HiLiteContent` now accepts either `children` (HTML) or `markdownContent` (Markdown string)
- Enhanced position mapping system to handle both HTML and Markdown content
- Updated TypeScript types to support the new Markdown mode